### PR TITLE
Add parameter -x to ignore the manifest

### DIFF
--- a/lib/Main.ts
+++ b/lib/Main.ts
@@ -14,6 +14,7 @@ function main() {
         .option("-s, --targetSubFolder <dir path>", "A relative sub folder in the destination to create and copy files to")
         .option("-n, --nextManifest <manifest file path>", "Next manifest file path")
         .option("-p, --previousManifest [manifest file path]", "Previous manifest file path")
+        .option("-x, --ignoreManifest", "Disables the processing of the manifest file")
         .option("-i, --ignore [patterns]", "List of files/directories to ignore and not sync, delimited by ;")
         .option("-q, --quiet", "No logging")
         .option("-v, --verbose [maxLines]", "Verbose logging with maximum number of output lines")
@@ -27,6 +28,7 @@ function main() {
     var targetSubFolder = commanderValues.targetSubFolder;
     var previousManifest = commanderValues.previousManifest;
     var nextManifest = commanderValues.nextManifest;
+    var ignoreManifest = commanderValues.ignoreManifest;
     var ignore = commanderValues.ignore;
     var quiet = commanderValues.quiet;
     var verbose = commanderValues.verbose;
@@ -97,6 +99,7 @@ function main() {
         targetSubFolder,
         nextManifest,
         previousManifest,
+        ignoreManifest,
         ignore,
         whatIf).then(
             () => {


### PR DESCRIPTION
- The -x option ignores the manifest and thereby allows a clean sync
(i.e. files in destination not present in the source will be deleted
blindly without needing a manifest)
- The .NET implementation of KuduSync already supports this
- With this change 'wardeploy' can use the -x option to do a kudusync to
any arbitrary directory. Without a clean kudusync (-x option), deploying
to arbitrary directories is error prone as the manifest isn't generated
per target directory, but is instead a global one. Deploying to a new
target directory while referring to manifest from an earlier target
directory is incorrect for obvious reasons.