### PR TITLE
Add test case for replacing a directory with a file

### DIFF
--- a/test/functionalTests.js
+++ b/test/functionalTests.js
@@ -263,6 +263,14 @@ suite('Kudu Sync Functional Tests', function () {
         });
     });
 
+    test('File remove and replaced with directory', function (done) {
+        runKuduSyncTestScenario(["file1", "dir1/LICENSE/LICENSE"], ["file1", "dir1/LICENSE/LICENSE"], null, function () {
+            var testedFiles = ["-dir1/LICENSE/LICENSE", "-dir1/LICENSE", "dir1/LICENSE"];
+            var expectedFiles = ["file1", "dir1/LICENSE"];
+            runKuduSyncTestScenario(testedFiles, expectedFiles, null, done);
+        });
+    });
+
     test('Clean before sync when it\'s the first sync (manifest is empty)', function (done) {
         generateToFile("dir1/dir2/tofile3");
         var testedFiles = ["file4", "file5", "file6"];


### PR DESCRIPTION
Consider a target directory containing a file `dir/file` and a source
directory containing a file `dir`. Note that in the target `dir` is a directory
and in the source `dir` is file. Currently `kudusync` does not remove the
directory in the target folder before attempting to create the file `dir`.

This PR adds a test case to show the problem. It does not fix the problem.