### PR TITLE
Ignore file/dir not found error during the delete operation

### DIFF
--- a/lib/FileUtils.ts
+++ b/lib/FileUtils.ts
@@ -111,7 +111,7 @@ function deleteFile(file: FileInfo, manifest: Manifest, rootPath: string, target
         log("Deleting file: '" + file.relativePath() + "'");
 
         if (!whatIf) {
-            return Utils.attempt(() => Q.nfcall(fs.unlink, path));
+            return Utils.attempt(() => Q.nfcall(fs.unlink, path), "ENOENT");
         }
     }
     
@@ -155,7 +155,7 @@ function deleteDirectoryRecursive(directory: DirectoryInfo, manifest: Manifest, 
             // Delete current directory
             log("Deleting directory: '" + relativePath + "'");
             if (!whatIf) {
-                return Utils.attempt(() => Q.nfcall(fs.rmdir, path));
+                return Utils.attempt(() => Q.nfcall(fs.rmdir, path), "ENOENT");
             }
             return Q.resolve();
         });

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -4,7 +4,7 @@ module Utils {
     private DefaultRetries: number = 3;
     private DefaultDelayBeforeRetry: number = 250; // 250 ms
         
-    export function attempt(action: () => Promise, retries: number = DefaultRetries, delayBeforeRetry: number = DefaultDelayBeforeRetry)  : Promise {
+    export function attempt(action: () => Promise, ignoreError: string = "", retries: number = DefaultRetries, delayBeforeRetry: number = DefaultDelayBeforeRetry)  : Promise {
         Ensure.argNotNull(action, "action");
         var currentTry = 1;
         
@@ -12,7 +12,10 @@ module Utils {
             return action().then(
                 Q.resolve,
                 function(err?) {
-                    if (retries >= currentTry++) {
+                    if (ignoreError && err && err.code && err.code == ignoreError) {
+                        Q.resolve;
+                    }
+                    else if (retries >= currentTry++) {
                         return Q.delay(Q.fcall(retryAction), delayBeforeRetry);
                     }
                     else {

--- a/test/attemptTests.js
+++ b/test/attemptTests.js
@@ -15,7 +15,7 @@ suite('Attempt Function Tests', function () {
             attempts.should.equal(0);
             attempts++;
             return Q.resolve();
-        }, 3, 10).then(function () {
+        }, null, 3, 10).then(function () {
             attempts.should.equal(1);
             done();
         });
@@ -31,7 +31,7 @@ suite('Attempt Function Tests', function () {
             }
 
             return Q.resolve();
-        }, 3, 10).then(function () {
+        }, null, 3, 10).then(function () {
             attempts.should.equal(2);
             done();
         });
@@ -47,7 +47,7 @@ suite('Attempt Function Tests', function () {
             }
 
             return Q.resolve();
-        }, 3, 10).then(function () {
+        }, null, 3, 10).then(function () {
             attempts.should.equal(3);
             done();
         });
@@ -63,7 +63,7 @@ suite('Attempt Function Tests', function () {
             }
 
             return Q.resolve();
-        }, 3, 10).then(function () {
+        }, null, 3, 10).then(function () {
             attempts.should.equal(4);
             done();
         });
@@ -79,7 +79,7 @@ suite('Attempt Function Tests', function () {
             }
 
             return Q.resolve();
-        }, 3, 10).fail(function (err) {
+        }, null, 3, 10).fail(function (err) {
             err.should.be.ok;
             err.message.should.equal("error");
             attempts.should.equal(4);


### PR DESCRIPTION
Kudu Sync currently fails when file/dir is not found during the delete operation. The change ensures that delete operation is considered successful if the file/dir is not-found/already-deleted. 